### PR TITLE
Extra error handling for direct calls

### DIFF
--- a/dummy/dummy.php
+++ b/dummy/dummy.php
@@ -373,8 +373,12 @@ function dummy($a, $internalcall = false) {
 // Check for the presense of a direct call
 // If that is the case, we call dummy() with the query part
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    $qs = $_SERVER['QUERY_STRING'];
+    if (getenv('DUMMYURL')) {
+        $qs = preg_replace('/^dummyurl=&/','', $qs);
+    }
     ob_start();
-    dummy($_SERVER['QUERY_STRING'], true);
+    dummy($qs, true);
     $content = ob_get_contents();
     ob_end_clean();
     // figure out the image type


### PR DESCRIPTION
This should give you a proper error message when the direct calling of images does not work. Don't forget to setup (and chmod) the /cache/-folder for images to work.
